### PR TITLE
Add light/dark contrast support

### DIFF
--- a/scripts/controllers/ColorGeneratorCtrl.js
+++ b/scripts/controllers/ColorGeneratorCtrl.js
@@ -74,12 +74,15 @@ function ($scope, $mdDialog, ColourLovers, $rootScope, $mdColorPalette )
 			// If this is an object with RGB/Contrast values (Default angularjs palettes)
 			if(typeof value == "object")
 			{
+				var color = {name: key};
+				color.darkContrast = value.contrast && value.contrast[0] === 0;
 				// Format it for tinycolor
 				value = "rgb(" + value.value[ 0 ] + ", " + value.value[ 1 ] + ", " + value.value[ 2 ] + ")";
+				color.hex = tinycolor(value).toHexString();
+				colors.push(color);
+			} else {
+				colors.push(getColorObject(value, key));
 			}
-
-			// Regardless, push this color to the colors using tinycolor!
-			colors.push( { hex: tinycolor( value ).toHexString(), name: key } );
 
 			// If this key is the base (500), set as base
 			if ( key == 500 || key == "500" ) {
@@ -96,6 +99,14 @@ function ($scope, $mdDialog, ColourLovers, $rootScope, $mdColorPalette )
 		$scope.palettes.push( palette );
 	};
 
+	function getColorObject(value, name) {
+		var c = tinycolor(value);
+		return {
+			name: name,
+			hex: c.toHexString(),
+			darkContrast: c.isLight()
+		};
+	}
 
 	// Function to add a palette to palettes.
 	$scope.addBasePalette = function()
@@ -148,10 +159,16 @@ function ($scope, $mdDialog, ColourLovers, $rootScope, $mdColorPalette )
 	// Function to make an exportable json array for themes.
 	$scope.makeColorsJson = function(colors){
 		var exportable = {};
+		var darkColors = [];
 		angular.forEach(colors, function(value, key){
 			exportable[value.name] = value.hex;
+			if (value.darkContrast) {
+				darkColors.push(value.name);
+			}
 		});
-		return angular.toJson(exportable, null, 4);
+		exportable.contrastDefaultColor = 'light';
+		exportable.contrastDarkColors = darkColors.join(' ');
+		return angular.toJson(exportable, 2).replace(/"/g, "'");
 	};
 
 	// Function to calculate all colors from base
@@ -164,20 +181,20 @@ function ($scope, $mdDialog, ColourLovers, $rootScope, $mdColorPalette )
 	{
 		// Return array of color objects.
 		return [
-			{ hex : tinycolor( hex ).lighten( 52 ).toHexString(), name : '50' },
-			{ hex : tinycolor( hex ).lighten( 37 ).toHexString(), name : '100' },
-			{ hex : tinycolor( hex ).lighten( 26 ).toHexString(), name : '200' },
-			{ hex : tinycolor( hex ).lighten( 12 ).toHexString(), name : '300' },
-			{ hex : tinycolor( hex ).lighten( 6 ).toHexString(), name : '400' },
-			{ hex : hex, name : '500' },
-			{ hex : tinycolor( hex ).darken( 6 ).toHexString(), name: '600' },
-			{ hex : tinycolor( hex ).darken( 12 ).toHexString(), name: '700' },
-			{ hex : tinycolor( hex ).darken( 18 ).toHexString(), name: '800' },
-			{ hex : tinycolor( hex ).darken( 24 ).toHexString(), name: '900' },
-			{ hex : tinycolor( hex ).lighten( 52 ).toHexString(), name: 'A100' },
-			{ hex : tinycolor( hex ).lighten( 37 ).toHexString(), name: 'A200' },
-			{ hex : tinycolor( hex ).lighten( 6 ).toHexString(), name: 'A400' },
-			{ hex : tinycolor( hex ).darken( 12 ).toHexString(), name: 'A700' }
+			getColorObject(tinycolor( hex ).lighten( 52 ), '50'),
+			getColorObject(tinycolor( hex ).lighten( 37 ), '100'),
+			getColorObject(tinycolor( hex ).lighten( 26 ), '200'),
+			getColorObject(tinycolor( hex ).lighten( 12 ), '300'),
+			getColorObject(tinycolor( hex ).lighten( 6 ), '400'),
+			getColorObject(tinycolor( hex ), '500'),
+			getColorObject(tinycolor( hex ).darken( 6 ), '600'),
+			getColorObject(tinycolor( hex ).darken( 12 ), '700'),
+			getColorObject(tinycolor( hex ).darken( 18 ), '800'),
+			getColorObject(tinycolor( hex ).darken( 24 ), '900'),
+			getColorObject(tinycolor( hex ).lighten( 52 ), 'A100'),
+			getColorObject(tinycolor( hex ).lighten( 37 ), 'A200'),
+			getColorObject(tinycolor( hex ).lighten( 6 ), 'A400'),
+			getColorObject(tinycolor( hex ).darken( 12 ), 'A700')
 		];
 	};
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -98,8 +98,14 @@ body .palette-colors md-list-item {
 	line-height: 35px;
 	width: 100%;
 	display: block;
+	min-height: 35px
+}
+.palette-color-light {
+	color: rgba(255, 255, 255, 0.87);
+	text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.1);
+}
+.palette-color-dark {
 	color: #000;
-	min-height: 35px;
 	text-shadow: 1px 1px 0px rgba(255, 255, 255, 0.1);
 }
 
@@ -112,7 +118,7 @@ body .palette-colors md-list-item {
 .palette-color-hex {
 	font-size: 11px;
 	text-transform: uppercase;
-	color: rgba(0, 0, 0, 0.5);
+	opacity: 0.7;
 }
 
 .palette-color-mutators {
@@ -121,6 +127,23 @@ body .palette-colors md-list-item {
 	top: -3px;
 	float: right;
 	height: 35px !important;
+}
+
+.palette-color-contrast {
+	display: inline-block;
+	float: right;
+	width: 20px;
+	height: 20px;
+	opacity: 0.7;
+	margin: 4px;
+}
+.palette-color-light .palette-color-contrast {
+	background: white;
+	border: 1px solid black;
+}
+.palette-color-dark .palette-color-contrast {
+	background: black;
+	border: 1px solid white;
 }
 
 .dot {

--- a/templates/color_generator.html
+++ b/templates/color_generator.html
@@ -65,7 +65,7 @@
         </md-toolbar>
 		<md-list flex class="palette-colors spaced">
 		    <md-list-item class="light-canvas" ng-repeat="color in palette.colors">
-		        <div class="palette-color" style="background-color:{{color.hex}};">
+		        <div class="palette-color" style="background-color:{{color.hex}};" ng-class="{'palette-color-light': !color.darkContrast, 'palette-color-dark': color.darkContrast}">
 		            <span class="name color-text" ng-bind="color.name"></span>
 		            <span ng-bind="color.hex" class="palette-color-hex color-text"></span>
 		            <a class="palette-color-hex color-text" href="http://colorhexa.com/{{color.hex.replace('#', '')}}" target="_blank">
@@ -75,6 +75,9 @@
                     <div class="palette-color-mutators">
                         <!-- Removed lighten and darken buttons until saturation issues are worked out. -->
                         <spectrum-colorpicker ng-model="color.hex" format="'hex'" options="{showInput: true, showPalette: true}"></spectrum-colorpicker>
+                    </div>
+                    <div class="palette-color-contrast" ng-click="color.darkContrast = !color.darkContrast">
+                      <md-tooltip>Toggle contrast</md-tooltip>
                     </div>
 		        </div>
 		    </md-list-item>


### PR DESCRIPTION
- From $mdColorPalette, obtain contrast information;
- for custom colors, calculate contrast information;
- allow to toggle contrast;
- export contrast to `$mdColorPalette` (as `contrastDefaultColor`, `contrastDarkColors`);

![2015-12-18-17-37-27_001](https://cloud.githubusercontent.com/assets/782446/11901845/135fc51e-a5ae-11e5-845a-6645f7d6d2c8.png)
