### PR TITLE
Update references to AngularJS 2 to match current Angular naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A tool for generating a color palette for Material Design.
 ###<a href="http://mcg.mbitson.com/">Click here to view the tool!</a>
 
 # What's New?
+* 7/29/17 - Updated references to AngularJS 2 to match [current Angular naming convention](https://angularjs.blogspot.com/2016/12/ok-let-me-explain-its-going-to-be.html).
 * 2/2/17 - Added support for Material UI's "Next" branch (React)
 * 2/1/17 - Let the user select which color calculation algorithm they'd like to use. (constantin/traditional[mcg])
 * 2/1/17 - Added the ability to link to a particular theme. URLs are now updated live as the theme is altered. Individual color alterations will not work with the URL method- use export/import.

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 
 	<!-- Load interpreter services -->
 	<script src="scripts/services/interpreters/angularJsInterpreter.js"></script>
-	<script src="scripts/services/interpreters/angularJs2Interpreter.js"></script>
+	<script src="scripts/services/interpreters/angularInterpreter.js"></script>
 	<script src="scripts/services/interpreters/materialUiInterpreter.js"></script>
 	<script src="scripts/services/interpreters/materialUiNextInterpreter.js"></script>
 	<script src="scripts/services/interpreters/androidInterpreter.js"></script>

--- a/scripts/controllers/DialogExportCtrl.js
+++ b/scripts/controllers/DialogExportCtrl.js
@@ -5,7 +5,7 @@ function DialogExportCtrl($scope, $mdDialog, $timeout, exportObj, single, theme,
 	$scope.formats = [
 		{ name: "Android XML", key: 'android'},
 		{ name: "Angular JS (Material)", key: 'angularjs'},
-		{ name: "Angular JS 2 (Material 2)", key: 'angularjs2'},
+		{ name: "Angular (Material 2)", key: 'angular'},
 		{ name: "Ember Paper", key: 'ember'},
 		{ name: "Material Design Lite (SCSS)", key: 'md-lite'},
 		{ name: "Material UI (React)", key: 'materialui'},

--- a/scripts/services/interpreters/angularInterpreter.js
+++ b/scripts/services/interpreters/angularInterpreter.js
@@ -1,4 +1,4 @@
-mcgApp.service('AngularJs2Interpreter', function () {
+mcgApp.service('AngularInterpreter', function () {
     this.export = function(exportObj, theme, single)
     {
         this.code = '';
@@ -10,7 +10,7 @@ mcgApp.service('AngularJs2Interpreter', function () {
     };
 
     /*
-     * AngularJS 2
+     * Angular versions 2+
      * Material 2 Formatting Functions
      */
     this.buildExport = function () {

--- a/scripts/services/interpreters/topInterpreter.js
+++ b/scripts/services/interpreters/topInterpreter.js
@@ -1,7 +1,7 @@
 mcgApp.service('TopInterpreter',
     [
         'AngularJsInterpreter',
-        'AngularJs2Interpreter',
+        'AngularInterpreter',
         'MaterialUiInterpreter',
         'MaterialUiNextInterpreter',
         'AndroidInterpreter',
@@ -11,7 +11,7 @@ mcgApp.service('TopInterpreter',
         'VueInterpreter',
         function(
             AngularJsInterpreter,
-            AngularJs2Interpreter,
+            AngularInterpreter,
             MaterialUiInterpreter,
             MaterialUiNextInterpreter,
             AndroidInterpreter,
@@ -26,8 +26,8 @@ mcgApp.service('TopInterpreter',
                 switch (name) {
                     case "angularjs":
                         return AngularJsInterpreter;
-                    case "angularjs2":
-                        return AngularJs2Interpreter;
+                    case "angular":
+                        return AngularInterpreter;
                     case "materialui":
                         return MaterialUiInterpreter;
                     case "materialuinext":


### PR DESCRIPTION
Per [this article from the Angular blog](https://angularjs.blogspot.com/2016/12/ok-let-me-explain-its-going-to-be.html) when referring to versions of Angular 2 and higher should be referred to as Angular.

This pr renames the  angularjs2Interpreter to angularInterpreter and updates the other references in the code to the current Angular naming conventions. Angular v5 will be released in September and these updates should help prevent confusion from end users since the palettes generated will still be valid for projects using  Angular Material with Angular releases later than 2. 