### PR TITLE
Added a quick fix for tetrad array element selection bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A tool for generating a color palette for Material Design.
 ###<a href="http://mcg.mbitson.com/">Click here to view the tool!</a>
 
 # What's New?
+* 1/28/19 - Added slight variation on "Constantin" algorithm.
 * 2/2/17 - Added support for Material UI's "Next" branch (React)
 * 2/1/17 - Let the user select which color calculation algorithm they'd like to use. (constantin/traditional[mcg])
 * 2/1/17 - Added the ability to link to a particular theme. URLs are now updated live as the theme is altered. Individual color alterations will not work with the URL method- use export/import.
@@ -36,3 +37,4 @@ A tool for generating a color palette for Material Design.
 * tkh44 - Optimizations/fixes
 * simon04 - Contrast detection, bug fixes.
 * Constantin - Color algorithm logic per stack overflow answer [here](http://stackoverflow.com/a/36229022/3525315).
+* [tabuckner](https://github.com/tabuckner) - Slight variation in 'Constantin' focusing on the A100 - A700 values.

--- a/scripts/controllers/ColorGeneratorCtrl.js
+++ b/scripts/controllers/ColorGeneratorCtrl.js
@@ -17,7 +17,8 @@ function ($scope, $mdDialog, ColourLovers, $rootScope, $mdColorPalette, $mdSiden
 		// Set algorithm options
 		$rootScope.settings.algorithms = [
 			'traditional',
-			'constantin'
+			'constantin',
+			'buckner'
 		];
 
 		// Set default settings
@@ -237,43 +238,67 @@ function ($scope, $mdDialog, ColourLovers, $rootScope, $mdColorPalette, $mdSiden
 	$scope.computeColors = function(hex)
 	{
 		// Return array of color objects.
-		if($rootScope.settings.algorithm == 'constantin'){
-			var baseLight = tinycolor('#ffffff');
-			var baseDark = $scope.multiply(tinycolor(hex).toRgb(), tinycolor(hex).toRgb());
-			var baseTriad = tinycolor(hex).tetrad();
-			return [
-				getColorObject(tinycolor.mix(baseLight, hex, 12), '50'),
-				getColorObject(tinycolor.mix(baseLight, hex, 30), '100'),
-				getColorObject(tinycolor.mix(baseLight, hex, 50), '200'),
-				getColorObject(tinycolor.mix(baseLight, hex, 70), '300'),
-				getColorObject(tinycolor.mix(baseLight, hex, 85), '400'),
-				getColorObject(tinycolor.mix(baseLight, hex, 100), '500'),
-				getColorObject(tinycolor.mix(baseDark, hex, 87), '600'),
-				getColorObject(tinycolor.mix(baseDark, hex, 70), '700'),
-				getColorObject(tinycolor.mix(baseDark, hex, 54), '800'),
-				getColorObject(tinycolor.mix(baseDark, hex, 25), '900'),
-				getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(80).lighten(65), 'A100'),
-				getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(80).lighten(55), 'A200'),
-				getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(100).lighten(45), 'A400'),
-				getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(100).lighten(40), 'A700')
-			];
-		}else{
-			return [
-				getColorObject(tinycolor(hex).lighten(52), '50'),
-				getColorObject(tinycolor(hex).lighten(37), '100'),
-				getColorObject(tinycolor(hex).lighten(26), '200'),
-				getColorObject(tinycolor(hex).lighten(12), '300'),
-				getColorObject(tinycolor(hex).lighten(6), '400'),
-				getColorObject(tinycolor(hex), '500'),
-				getColorObject(tinycolor(hex).darken(6), '600'),
-				getColorObject(tinycolor(hex).darken(12), '700'),
-				getColorObject(tinycolor(hex).darken(18), '800'),
-				getColorObject(tinycolor(hex).darken(24), '900'),
-				getColorObject(tinycolor(hex).lighten(50).saturate(30), 'A100'),
-				getColorObject(tinycolor(hex).lighten(30).saturate(30), 'A200'),
-				getColorObject(tinycolor(hex).lighten(10).saturate(15), 'A400'),
-				getColorObject(tinycolor(hex).lighten(5).saturate(5), 'A700')
-			];
+		switch ($rootScope.settings.algorithm) {
+			case 'constantin':
+				var baseLight = tinycolor('#ffffff');
+				var baseDark = $scope.multiply(tinycolor(hex).toRgb(), tinycolor(hex).toRgb());
+				var baseTriad = tinycolor(hex).tetrad();
+				return [
+					getColorObject(tinycolor.mix(baseLight, hex, 12), '50'),
+					getColorObject(tinycolor.mix(baseLight, hex, 30), '100'),
+					getColorObject(tinycolor.mix(baseLight, hex, 50), '200'),
+					getColorObject(tinycolor.mix(baseLight, hex, 70), '300'),
+					getColorObject(tinycolor.mix(baseLight, hex, 85), '400'),
+					getColorObject(tinycolor.mix(baseLight, hex, 100), '500'),
+					getColorObject(tinycolor.mix(baseDark, hex, 87), '600'),
+					getColorObject(tinycolor.mix(baseDark, hex, 70), '700'),
+					getColorObject(tinycolor.mix(baseDark, hex, 54), '800'),
+					getColorObject(tinycolor.mix(baseDark, hex, 25), '900'),
+					getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(80).lighten(65), 'A100'),
+					getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(80).lighten(55), 'A200'),
+					getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(100).lighten(45), 'A400'),
+					getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(100).lighten(40), 'A700')
+				];
+		
+			case 'buckner': 
+				var baseLight = tinycolor('#ffffff');
+				var baseDark = $scope.multiply(tinycolor(hex).toRgb(), tinycolor(hex).toRgb());
+				var baseTriad = tinycolor(hex).tetrad();
+
+				return [
+					getColorObject(tinycolor.mix(baseLight, hex, 12), '50'),
+					getColorObject(tinycolor.mix(baseLight, hex, 30), '100'),
+					getColorObject(tinycolor.mix(baseLight, hex, 50), '200'),
+					getColorObject(tinycolor.mix(baseLight, hex, 70), '300'),
+					getColorObject(tinycolor.mix(baseLight, hex, 85), '400'),
+					getColorObject(tinycolor.mix(baseLight, hex, 100), '500'),
+					getColorObject(tinycolor.mix(baseDark, hex, 87), '600'),
+					getColorObject(tinycolor.mix(baseDark, hex, 70), '700'),
+					getColorObject(tinycolor.mix(baseDark, hex, 54), '800'),
+					getColorObject(tinycolor.mix(baseDark, hex, 25), '900'),
+					getColorObject(tinycolor.mix(baseDark, baseTriad[3], 15).saturate(80).lighten(48), 'A100'),
+					getColorObject(tinycolor.mix(baseDark, baseTriad[3], 15).saturate(80).lighten(36), 'A200'),
+					getColorObject(tinycolor.mix(baseDark, baseTriad[3], 15).saturate(100).lighten(31), 'A400'),
+					getColorObject(tinycolor.mix(baseDark, baseTriad[3], 15).saturate(100).lighten(28), 'A700')
+				];
+
+			default:
+				return [
+					getColorObject(tinycolor(hex).lighten(52), '50'),
+					getColorObject(tinycolor(hex).lighten(37), '100'),
+					getColorObject(tinycolor(hex).lighten(26), '200'),
+					getColorObject(tinycolor(hex).lighten(12), '300'),
+					getColorObject(tinycolor(hex).lighten(6), '400'),
+					getColorObject(tinycolor(hex), '500'),
+					getColorObject(tinycolor(hex).darken(6), '600'),
+					getColorObject(tinycolor(hex).darken(12), '700'),
+					getColorObject(tinycolor(hex).darken(18), '800'),
+					getColorObject(tinycolor(hex).darken(24), '900'),
+					getColorObject(tinycolor(hex).lighten(50).saturate(30), 'A100'),
+					getColorObject(tinycolor(hex).lighten(30).saturate(30), 'A200'),
+					getColorObject(tinycolor(hex).lighten(10).saturate(15), 'A400'),
+					getColorObject(tinycolor(hex).lighten(5).saturate(5), 'A700')
+				];
 		}
 	};
 

--- a/scripts/controllers/ColorGeneratorCtrl.js
+++ b/scripts/controllers/ColorGeneratorCtrl.js
@@ -252,10 +252,10 @@ function ($scope, $mdDialog, ColourLovers, $rootScope, $mdColorPalette, $mdSiden
 				getColorObject(tinycolor.mix(baseDark, hex, 70), '700'),
 				getColorObject(tinycolor.mix(baseDark, hex, 54), '800'),
 				getColorObject(tinycolor.mix(baseDark, hex, 25), '900'),
-				getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(80).lighten(65), 'A100'),
-				getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(80).lighten(55), 'A200'),
-				getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(100).lighten(45), 'A400'),
-				getColorObject(tinycolor.mix(baseDark, baseTriad[4], 15).saturate(100).lighten(40), 'A700')
+				getColorObject(tinycolor.mix(baseDark, baseTriad[3], 15).saturate(80).lighten(48), 'A100'),
+				getColorObject(tinycolor.mix(baseDark, baseTriad[3], 15).saturate(80).lighten(36), 'A200'),
+				getColorObject(tinycolor.mix(baseDark, baseTriad[3], 15).saturate(100).lighten(31), 'A400'),
+				getColorObject(tinycolor.mix(baseDark, baseTriad[3], 15).saturate(100).lighten(28), 'A700')
 			];
 		}else{
 			return [

--- a/templates/color_generator.html
+++ b/templates/color_generator.html
@@ -152,6 +152,7 @@
 	            <ul>
 		            <li>"Traditional" is the original MCG logic. It creates a lower contrast palette.</li>
 	                <li>"Constantin" is the logic that was developed based on the outline from <a href="http://stackoverflow.com/questions/28503998/how-to-create-custom-palette-with-custom-color-for-material-design-app/36229022#36229022">here</a>. It creates a higher contrast palette.</li>
+	                <li>"Buckner" is a slight variation in "Constantin" focusing on the A100 - A700 hues.</li>
 	            </ul>
             </span>
         </form>


### PR DESCRIPTION
@mbitson @fireflight1 @simon04 Discovered this while making a SASS adaptation of your approach. Thank you so much for making this open source! It's still not perfect, and might not look good for all colors, but I feel it's a closer approximation.

`tinycolor.tetrad()` returns an array with a length of 4. Targeting index `[4]` returns `undefined`. `tinycolor.mix()` does not complain about an undefined value for argument 2, but we're not correctly handling the mix approach. 

Using @angular/material as a baseline, I tweaked the values to somewhat more closely match the `mat-indigo` palette.

```javascript
// @angular/material mat-indigo palette
mat-indigo = {
  50: #e8eaf6,
  100: #c5cae9,
  200: #9fa8da,
  300: #7986cb,
  400: #5c6bc0,
  500: #3f51b5,
  600: #3949ab,
  700: #303f9f,
  800: #283593,
  900: #1a237e,
  A100: #8c9eff,
  A200: #536dfe,
  A400: #3d5afe,
  A700: #304ffe
};
```

```javascript
// new output with same base color
testMap = {
  50: #e8eaf6,
  100: #c5cbe9,
  200: #9fa8da,
  300: #7985cb,
  400: #5c6bc0,
  500: #3f51b5,
  600: #394aae,
  700: #3140a5,
  800: #29379d,
  900: #1b278d,
  A100: #88a6ff,
  A200: #4b79ff,
  A400: #3166ff,
  A700: #225aff
};
```
Mat-Indigo
![image](https://user-images.githubusercontent.com/32392635/51846845-05647880-22e0-11e9-9ce3-c7f7a6315e79.png)

New values
![image](https://user-images.githubusercontent.com/32392635/51846816-f7165c80-22df-11e9-83e9-2754c4bc5fd1.png)
