### PR TITLE
1 fails to build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "angular-material-icons": "^0.6",
     "jquery": "~2.1.3",
     "spectrum": "1.6.0",
-    "angular-spectrum-colorpicker": "~1.3.5",
+    "angular-spectrum-colorpicker": "git://github.com/powwowinc/angular-spectrum-colorpicker.git",
     "tinycolor": "~1.2.1",
     "angular-toArrayFilter": "~1.0.1",
     "prism": "^1.6.0",

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "angular-route": "latest",
     "angular-material-icons": "^0.6",
     "jquery": "~2.1.3",
-    "spectrum": "1.6.0",
+    "spectrum": "1.7.0",
     "angular-spectrum-colorpicker": "git://github.com/powwowinc/angular-spectrum-colorpicker.git",
     "tinycolor": "~1.2.1",
     "angular-toArrayFilter": "~1.0.1",


### PR DESCRIPTION
update dependency _angular-spectrum-colorpicker_ with one that's not missing and uplift the dependent package _spectrum_.